### PR TITLE
- Changed the HTTP method "POST" to "GET" because there are no inform…

### DIFF
--- a/OpenIdConnect/JWK/JWKSetHandler.php
+++ b/OpenIdConnect/JWK/JWKSetHandler.php
@@ -106,7 +106,7 @@ class JWKSetHandler
     
     private function makeCache()
     {
-        $request = new HttpClientRequest(RequestInterface::METHOD_POST, $this->jwkUrl);        
+        $request = new HttpClientRequest(RequestInterface::METHOD_GET, $this->jwkUrl);        
         $response = new HttpClientResponse();
         $this->httpClient->send($request, $response);
         


### PR DESCRIPTION
…ations sended to the server. Furthermore the .jwk file/response might be not reachable with POST method (HTTP Error 405 Method not allowed)
